### PR TITLE
Added AllowIncompatibleVanillaEnchantments

### DIFF
--- a/plugin/src/main/java/me/badbones69/crazyenchantments/api/CrazyEnchantments.java
+++ b/plugin/src/main/java/me/badbones69/crazyenchantments/api/CrazyEnchantments.java
@@ -54,6 +54,7 @@ public class CrazyEnchantments {
     private boolean enchantStackedItems;
     private boolean maxEnchantmentCheck;
     private boolean checkVanillaLimit;
+    private boolean allowIncompatibleVanillaEnchantments;
     private ItemBuilder enchantmentBook;
     private NMSSupport nmsSupport;
     private Random random = new Random();
@@ -110,6 +111,7 @@ public class CrazyEnchantments {
         }
         whiteScrollProtectionName = Methods.color(config.getString("Settings.WhiteScroll.ProtectedName"));
         enchantmentBook = new ItemBuilder().setMaterial(config.getString("Settings.Enchantment-Book-Item"));
+        allowIncompatibleVanillaEnchantments = config.getBoolean("Settings.BlackSmith.AllowIncompatibleVanillaEnchantments");
         useUnsafeEnchantments = config.getBoolean("Settings.EnchantmentOptions.UnSafe-Enchantments");
         maxEnchantmentCheck = config.getBoolean("Settings.EnchantmentOptions.MaxAmountOfEnchantmentsToggle");
         checkVanillaLimit = config.getBoolean("Settings.EnchantmentOptions.IncludeVanillaEnchantments");
@@ -413,6 +415,14 @@ public class CrazyEnchantments {
      */
     public boolean useUnsafeEnchantments() {
         return useUnsafeEnchantments;
+    }
+    
+    /**
+     * Check if the config has unsafe enchantments enabled.
+     * @return True if enabled and false if not.
+     */
+    public boolean allowIncompatibleVanillaEnchantments() {
+        return allowIncompatibleVanillaEnchantments;
     }
     
     public boolean useMaxEnchantmentLimit() {

--- a/plugin/src/main/java/me/badbones69/crazyenchantments/api/managers/BlackSmithManager.java
+++ b/plugin/src/main/java/me/badbones69/crazyenchantments/api/managers/BlackSmithManager.java
@@ -44,6 +44,7 @@ public class BlackSmithManager {
         levelUp = config.getInt("Settings.BlackSmith.Transaction.Costs.Power-Up", 5);
         addEnchantment = config.getInt("Settings.BlackSmith.Transaction.Costs.Add-Enchantment", 3);
         maxEnchantments = config.getBoolean("Settings.EnchantmentOptions.MaxAmountOfEnchantmentsToggle");
+        allowIncompatibleVanillaEnchantments = config.getBoolean("Settings.BlackSmith.AllowIncompatibleVanillaEnchantments");
     }
     
     public ItemStack getDenyBarrier() {

--- a/plugin/src/main/java/me/badbones69/crazyenchantments/api/managers/BlackSmithManager.java
+++ b/plugin/src/main/java/me/badbones69/crazyenchantments/api/managers/BlackSmithManager.java
@@ -92,4 +92,8 @@ public class BlackSmithManager {
         return maxEnchantments;
     }
     
+    public boolean allowIncompatibleVanillaEnchantments() {
+        return allowIncompatibleVanillaEnchantments;   
+    }
+    
 }

--- a/plugin/src/main/java/me/badbones69/crazyenchantments/api/managers/BlackSmithManager.java
+++ b/plugin/src/main/java/me/badbones69/crazyenchantments/api/managers/BlackSmithManager.java
@@ -22,6 +22,7 @@ public class BlackSmithManager {
     private int levelUp;
     private int addEnchantment;
     private boolean maxEnchantments;
+    private boolean allowIncompatibleVanillaEnchantments;
     
     public static BlackSmithManager getInstance() {
         return instance;

--- a/plugin/src/main/java/me/badbones69/crazyenchantments/api/objects/CEItem.java
+++ b/plugin/src/main/java/me/badbones69/crazyenchantments/api/objects/CEItem.java
@@ -39,6 +39,15 @@ public class CEItem {
         return vanillaEnchantments.getOrDefault(enchantment, 0);
     }
     
+    public boolean vanillaEnchantmentConflictsWith(Enchantment enchantment) {
+        for(Enchantment i : vanillaEnchantments.keySet()) {
+            if(enchantment.conflictsWith(i)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
     public Map<Enchantment, Integer> getVanillaEnchantments() {
         return vanillaEnchantments;
     }

--- a/plugin/src/main/resources/config1.12.2-Down.yml
+++ b/plugin/src/main/resources/config1.12.2-Down.yml
@@ -91,6 +91,7 @@ Settings:
       - ''
       - '&eCost: &e&l$500'
   BlackSmith: #Options for the Black Smith
+    AllowIncompatibleVanillaEnchantments: false # Allows combining incompatible vanilla enchantments if true. Removes the incompatible enchantments if false. (e.g. combining a bow with infinity to another with mending)
     InGUI: true #In the GUI.
     Slot: 24 #Slot it is in.
     Item: 'ANVIL' #Item that shows in the GUI

--- a/plugin/src/main/resources/config1.13-Up.yml
+++ b/plugin/src/main/resources/config1.13-Up.yml
@@ -90,6 +90,7 @@ Settings:
       - ''
       - '&eCost: &e&l$500'
   BlackSmith: #Options for the Black Smith
+    AllowIncompatibleVanillaEnchantments: false # Allows combining incompatible vanilla enchantments if true. Removes the incompatible enchantments if false. (e.g. combining a bow with infinity to another with mending)
     InGUI: true #In the GUI.
     Slot: 24 #Slot it is in.
     Item: 'ANVIL' #Item that shows in the GUI


### PR DESCRIPTION
BlackSmith.AllowIncompatibleVanillaEnchantments
If true, allows combining incompatible vanilla enchantments via BlackSmith (e.g. combining a bow with infinity to one with mending)
If false, it removes the incompatible enchantments from the item in the second slot and keeps the ones in the item in the first slot.